### PR TITLE
Service目录下的类型补充

### DIFF
--- a/src/service/administrativeDivision.d.ts
+++ b/src/service/administrativeDivision.d.ts
@@ -1,0 +1,125 @@
+interface RegionParents {
+  /** 行政区划名称 */
+  name: string;
+
+  /** 行政区划类别(省市县) */
+  adminType: string;
+
+  /** 行政区划码 */
+  cityCode: string;
+
+  /** 国家信息 */
+  country: CountryInfo;
+}
+
+interface CountryInfo {
+  /** 国家名称 */
+  name: string;
+
+  /** 行政区划类别 */
+  adminType: string;
+
+  /** 国家代码 */
+  cityCode: string;
+}
+
+interface RegionPoint {
+  /** 行政区划范围 格式："lng lat, lng lat,..." */
+  region: string;
+}
+
+interface AdministrativeDivisionData {
+
+  /** 父级区划信息 */
+  parents: RegionParents;
+
+  /** 行政区划等级 */
+  level: number;
+
+  /** 行政区划简称 */
+  nameabbrevation: string;
+
+  /** 行政区划名称 */
+  name: string;
+
+  /** 行政区划类别 */
+  adminType: string;
+
+  /** 行政区划码 */
+  cityCode: string;
+
+  /** 行政区划中心点 经度 */
+  lnt: number;
+
+  /** 行政区划中心点 纬度 */
+  lat: number;
+
+  /** 行政区划英文简称 */
+  englishabbrevation: string;
+
+  /** 行政区划英文名称 */
+  english: string;
+
+  /** 行政区划范围 格式："lng,lat,lng,lat,... */
+  bound: string;
+
+  /** 行政区划范围 */
+  points: RegionPoint[];
+
+};
+
+type AdministrativeDivisionSearchCallback = (result: AdministrativeDivisionResult) => void;
+
+declare namespace T {
+  class AdministrativeDivision {
+    /** 创建一个获取行政区划的实例。此类用于获取行政区划信息。 */
+    constructor();
+
+    /**
+     * 根据检索词发起检索。参数说明：
+     * @param config：详见AdministrativeDivisionOptions类。
+     * @param callback：设置回调函数。
+     * 回调函数参数为AdministrativeDivisionResult，具体内容详见AdministrativeDivisionResult类。
+     */
+    search(config: AdministrativeDivisionOptions, callback: AdministrativeDivisionSearchCallback): void;
+  }
+
+  /** 此类用于获取行政区划信息。 */
+  interface AdministrativeDivisionOptions {
+
+    /** 查询行政区划的名称。 */
+    searchWord?: string;
+
+    /** 查询类型。0表示根据code查询，1表示根据名称查询。 */
+    searchType?: number;
+
+    /** 是否需要下一级信息。 */
+    needSubInfo?: boolean;
+
+    /** 是否需要所有子节点。 */
+    needAll?: boolean;
+
+    /** 是否需要行政区划范围。 */
+    needPolygon?: boolean;
+
+    /** 是否需要上一级所有信息。 */
+    needPre?: boolean;
+  }
+
+  /** 此类表示T. AdministrativeDivision的检索结果，没有构造函数。 */
+  interface AdministrativeDivisionResult {
+
+    /** 返回状态码，100表示正常，101表示没有查到结果。 */
+    getStatus: () => number;
+
+    /** 返回响应信息。 */
+    getMsg: () => string | null;
+
+    /** 返回数据版本。文档说明有误，文档为LngLat，实为string。 */
+    getDataVersion: () => string | null;
+
+    /** 返回行政区划数据信息。文档说明有误，文档为string，实为一个对象。 */
+    getData: () => AdministrativeDivisionData | null;
+  }
+
+}

--- a/src/service/administrativeDivision.d.ts
+++ b/src/service/administrativeDivision.d.ts
@@ -68,8 +68,6 @@ interface AdministrativeDivisionData {
 
 };
 
-type AdministrativeDivisionSearchCallback = (result: AdministrativeDivisionResult) => void;
-
 declare namespace T {
   class AdministrativeDivision {
     /** 创建一个获取行政区划的实例。此类用于获取行政区划信息。 */
@@ -77,8 +75,8 @@ declare namespace T {
 
     /**
      * 根据检索词发起检索。参数说明：
-     * @param config：详见AdministrativeDivisionOptions类。
-     * @param callback：设置回调函数。
+     * config：详见AdministrativeDivisionOptions类。
+     * callback：设置回调函数。
      * 回调函数参数为AdministrativeDivisionResult，具体内容详见AdministrativeDivisionResult类。
      */
     search(config: AdministrativeDivisionOptions, callback: AdministrativeDivisionSearchCallback): void;
@@ -120,6 +118,9 @@ declare namespace T {
 
     /** 返回行政区划数据信息。文档说明有误，文档为string，实为一个对象。 */
     getData: () => AdministrativeDivisionData | null;
+
   }
+
+  type AdministrativeDivisionSearchCallback = (result: AdministrativeDivisionResult) => void;
 
 }

--- a/src/service/dataSources.d.ts
+++ b/src/service/dataSources.d.ts
@@ -1,0 +1,32 @@
+type DataSourcesSearchCallback = (result: any) => void;
+
+declare namespace T {
+  class DataSources {
+    /** 创建一个获取数据来源的实例。此类用于获取地图数据来源信息。 */
+    constructor();
+
+    /**
+     * 查询当前地图数据的来源。参数说明：
+     * @param config：详见DataSourcesOptions类。
+     * @param callback：设置回调函数。回调函数参数为JSON对象，具体内容如下：{ "ds": "数据来源"}
+     */
+    search(config: DataSourcesOptions, callback: DataSourcesSearchCallback): void;
+  }
+
+  /** 此类用于获取地图数据来源信息。 */
+  interface DataSourcesOptions {
+    /** 地图级别。 */
+    level: number;
+
+    /** 地图范围。 */
+    bound: string;
+
+    /** 地图图层。 */
+    layers: string;
+
+    /** 地图投影。 */
+    projection: string;
+
+  }
+
+}

--- a/src/service/dataSources.d.ts
+++ b/src/service/dataSources.d.ts
@@ -1,5 +1,3 @@
-type DataSourcesSearchCallback = (result: any) => void;
-
 declare namespace T {
   class DataSources {
     /** 创建一个获取数据来源的实例。此类用于获取地图数据来源信息。 */
@@ -28,5 +26,7 @@ declare namespace T {
     projection: string;
 
   }
+
+  type DataSourcesSearchCallback = (result: any) => void;
 
 }

--- a/src/service/geoLocation.d.ts
+++ b/src/service/geoLocation.d.ts
@@ -1,5 +1,3 @@
-type GeolocationGetLocationCallback = (result: GeolocationResult) => void;
-
 declare namespace T {
   class Geolocation {
     /** 创建Geolocation对象实例。返回用户当前的位置。此方法利用浏览器的geolocation接口获取用户当前位置，不支持的浏览器将无法获取。 */
@@ -15,7 +13,7 @@ declare namespace T {
     getStatus(): GeolocationStatusCode | undefined;
 
     /** 返回用户当前位置。当定位成功时，回调函数的参数为GeolocationResult对象，否则为null。 */
-    getCurrentPosition(callback: GeolocationGetLocationCallback, options: GeolocationOptions): void;
+    getCurrentPosition(callback: GeolocationGetLocationCallback, options?: GeolocationOptions): void;
   }
 
   /** H5定位返回结果的对象 */
@@ -32,13 +30,13 @@ declare namespace T {
   interface GeolocationOptions {
 
     /** 要求浏览器获取最佳结果。 */
-    enableHighAccuracy: boolean;
+    enableHighAccuracy?: boolean;
 
     /** 允许返回指定时间内的缓存结果。如果此值为0，则浏览器将立即获取新定位结果。 */
-    maximumAge: number;
+    maximumAge?: number;
 
     /** 超时时间。 */
-    timeout: number;
+    timeout?: number;
   }
 
   /** 返回状态码 */
@@ -49,5 +47,7 @@ declare namespace T {
     TDT_STATUS_PERMISSION_DENIED = 3,
     TDT_STATUS_UNKNOWN_ERROR = 5,
   }
+
+  type GeolocationGetLocationCallback = (result: GeolocationResult | null) => void;
 
 }

--- a/src/service/geoLocation.d.ts
+++ b/src/service/geoLocation.d.ts
@@ -1,0 +1,46 @@
+declare namespace T {
+  class Geolocation {
+    /** 返回用户当前的位置。此方法利用浏览器的geolocation接口获取用户当前位置，不支持的浏览器将无法获取。 */
+    constructor();
+
+    /** 返回状态码，当定位成功后，状态码为：TDT_STATUS_SUCCESS，如果为其他状态码表示不能获取您当前的位置。TDT_STATUS_CITY_LIST ,返回城市列表。TDT_STATUS_PERMISSION_DENIED，用户拒绝提供地理位置。TDT_STATUS_UNKNOWN_ERROR=5，未知错误。 */
+    getStatus(): GeolocationStatusCode | undefined;
+
+    /** 返回用户当前位置。当定位成功时，回调函数的参数为GeolocationResult对象，否则为null。 */
+    getCurrentPosition(callback: GeolocationGetLocationCallback, options: GeolocationOptions): void;
+  }
+
+  /** H5定位返回结果的对象 */
+  interface GeolocationResult {
+    /** 定位返回的坐标点。 */
+    lnglat: LngLat;
+
+    /** 定位精确程度，单位为米。 */
+    accuracyNumber: number;
+  }
+
+  /** 此类作为getCurrentPosition的可选参数，不能实例化 */
+  interface GeolocationOptions {
+    /** 要求浏览器获取最佳结果。 */
+    enableHighAccuracy: boolean;
+
+    /** 允许返回指定时间内的缓存结果。如果此值为0，则浏览器将立即获取新定位结果。 */
+    maximumAge: number;
+
+    /** 超时时间。 */
+    timeout: number;
+  }
+
+  /** 定位的回调 推荐使用匿名函数，箭头函数在当前天地图版本可能会有polyfill问题 */
+  type GeolocationGetLocationCallback = (result: GeolocationResult) => void;
+
+  /** 返回状态码 */
+  enum GeolocationStatusCode {
+    TDT_STATUS_SUCCESS = 0,
+    TDT_STATUS_CITY_LIST = 1,
+    TDT_STATUS_POSITION_UNAVAILABLE = 2,
+    TDT_STATUS_PERMISSION_DENIED = 3,
+    TDT_STATUS_UNKNOWN_ERROR = 5,
+  }
+
+}

--- a/src/service/geoLocation.d.ts
+++ b/src/service/geoLocation.d.ts
@@ -1,9 +1,17 @@
+type GeolocationGetLocationCallback = (result: GeolocationResult) => void;
+
 declare namespace T {
   class Geolocation {
-    /** 返回用户当前的位置。此方法利用浏览器的geolocation接口获取用户当前位置，不支持的浏览器将无法获取。 */
+    /** 创建Geolocation对象实例。返回用户当前的位置。此方法利用浏览器的geolocation接口获取用户当前位置，不支持的浏览器将无法获取。 */
     constructor();
 
-    /** 返回状态码，当定位成功后，状态码为：TDT_STATUS_SUCCESS，如果为其他状态码表示不能获取您当前的位置。TDT_STATUS_CITY_LIST ,返回城市列表。TDT_STATUS_PERMISSION_DENIED，用户拒绝提供地理位置。TDT_STATUS_UNKNOWN_ERROR=5，未知错误。 */
+    /**
+     * 返回状态码，当定位成功后，状态码为：
+     * TDT_STATUS_SUCCESS，如果为其他状态码表示不能获取您当前的位置。
+     * TDT_STATUS_CITY_LIST ,返回城市列表。
+     * TDT_STATUS_PERMISSION_DENIED，用户拒绝提供地理位置。
+     * TDT_STATUS_UNKNOWN_ERROR=5，未知错误。
+     */
     getStatus(): GeolocationStatusCode | undefined;
 
     /** 返回用户当前位置。当定位成功时，回调函数的参数为GeolocationResult对象，否则为null。 */
@@ -12,6 +20,7 @@ declare namespace T {
 
   /** H5定位返回结果的对象 */
   interface GeolocationResult {
+
     /** 定位返回的坐标点。 */
     lnglat: LngLat;
 
@@ -21,6 +30,7 @@ declare namespace T {
 
   /** 此类作为getCurrentPosition的可选参数，不能实例化 */
   interface GeolocationOptions {
+
     /** 要求浏览器获取最佳结果。 */
     enableHighAccuracy: boolean;
 
@@ -30,9 +40,6 @@ declare namespace T {
     /** 超时时间。 */
     timeout: number;
   }
-
-  /** 定位的回调 推荐使用匿名函数，箭头函数在当前天地图版本可能会有polyfill问题 */
-  type GeolocationGetLocationCallback = (result: GeolocationResult) => void;
 
   /** 返回状态码 */
   enum GeolocationStatusCode {

--- a/src/service/geocoder.d.ts
+++ b/src/service/geocoder.d.ts
@@ -1,9 +1,4 @@
-type GeocoderGetLocationCallback = (result: GeocoderResult) => void;
-
-type GeocoderGetPointCallback = (result: GeocoderResult) => void;
-
 declare namespace T {
-
   class Geocoder {
     /** 创建一个地址解析器的实例。此类用于获取用户的地址解析 */
     constructor();
@@ -16,26 +11,25 @@ declare namespace T {
   }
 
   /** 此类表示Geocoder的地址解析结果。它在地址解析的回调函数的参数中返回，不可实例化。 */
-  class GeocoderResult {
-    constructor();
+  interface GeocoderResult {
 
     /** 返回响应结果。 */
-    getStatus(): number;
+    getStatus: () => number;
 
     /** 返回响应信息。 */
-    getMsg(): string;
+    getMsg: () => string;
 
     /** 获取此点坐标。 */
-    getLocationPoint(): LngLat;
+    getLocationPoint: () => LngLat;
 
     /** 获取详细地址。 */
-    getAddress(): string | null;
+    getAddress: () => string | null;
 
     /** 获取此点的详细信息。 */
-    getAddressComponent(): AddressComponent;
+    getAddressComponent: () => AddressComponent;
 
     /** 获取此点类别。 */
-    getLocationLevel(): string | undefined;
+    getLocationLevel: () => string | undefined;
   }
 
   /** 此类表示地址解析结果的层次化地址信息，没有构造函数，通过对象字面量形式表示。 */
@@ -126,5 +120,9 @@ declare namespace T {
     poi_position: string;
 
   }
+
+  type GeocoderGetLocationCallback = (result: GeocoderResult) => void;
+
+  type GeocoderGetPointCallback = (result: GeocoderResult) => void;
 
 }

--- a/src/service/geocoder.d.ts
+++ b/src/service/geocoder.d.ts
@@ -1,0 +1,128 @@
+type GeocoderGetLocationCallback = (result: GeocoderResult) => void;
+
+type GeocoderGetPointCallback = (result: GeocoderResult) => void;
+
+declare namespace T {
+  class Geocoder {
+    /** 创建一个地址解析器的实例。 */
+    constructor();
+
+    /** 对指定的坐标点进行反地址解析。如果解析成功，则回调函数的参数为GeocoderResult对象。 */
+    getLocation(point: LngLat, callback: GeocoderGetLocationCallback): void;
+
+    /** 对指定的地址进行地址解析。如果解析成功，则回调函数的参数为GeocoderResult对象。 */
+    getPoint(loction: string, callback: GeocoderGetPointCallback): void;
+  }
+
+  /** 此类表示Geocoder的地址解析结果。它在地址解析的回调函数的参数中返回，不可实例化。 */
+  class GeocoderResult {
+    constructor();
+
+    /** 返回响应结果。 */
+    getStatus(): number;
+
+    /** 返回响应信息。 */
+    getMsg(): string;
+
+    /** 获取此点坐标。 */
+    getLocationPoint(): LngLat;
+
+    /** 获取详细地址。 */
+    getAddress(): string | null;
+
+    /** 获取此点的详细信息。 */
+    getAddressComponent(): AddressComponent;
+
+    /** 获取此点类别。 */
+    getLocationLevel(): string | undefined;
+  }
+
+  /** 此类表示地址解析结果的层次化地址信息，没有构造函数，通过对象字面量形式表示。 */
+  interface AddressComponent {
+    /** 此点最近地点信息 */
+    address: string;
+
+    /** 此点距离最近地点信息距离 */
+    address_distance: number;
+
+    /** 此点在最近地点信息方向 */
+    address_position: string;
+
+    /** 此点所在国家或城市或区县 */
+    city: string;
+
+    /** 距离此点最近poi点 */
+    poi: string;
+
+    /** 距离此点最近poi点的距离 */
+    poi_distance: number;
+
+    /** 此点在最近poi点的方向 */
+    poi_position: string;
+
+    /** 距离此点最近的路 */
+    road: string;
+
+    /** 此点距离此路的距离 */
+    road_distance: number;
+
+    /** (文档未给出) 层次化地址信息的详细结果 */
+    addressComponent: AddressComponentDetail;
+  }
+
+  /** 地址解析结果的层次化地址信息的详细版本 */
+  interface AddressComponentDetail {
+
+    /** 此点最近地点信息 */
+    address: string;
+
+    /** 此点最近地点信息 */
+    address_distance: number;
+
+    /** 此点在最近地点信息方向 */
+    address_position: string;
+
+    /** 此点所在国家 */
+    nation: string;
+
+    /** 此点所在省份 */
+    province: string;
+
+    /** 此点所在省份代码  由国家代码ISO 3166-1（固定为156）+ 省份代码（6位）拼接组成 */
+    province_code: string;
+
+    /** 此点所在城市 */
+    city: string;
+
+    /** 此点所在城市代码 由国家代码ISO 3166-1（固定为156）+ 城市代码（6位）拼接组成 */
+    city_code: number;
+
+    /** 此点所在区县 */
+    county: string;
+
+    /** 此点所在区/县代码  由国家代码ISO 3166-1（固定为156）+ 区/县代码（6位）拼接组成 */
+    county_code: string;
+
+    /** 此点所在乡/镇/街道 */
+    town: string;
+
+    /** 此点所在乡/镇/街道代码  由国家代码ISO 3166-1（固定为156）+ 区/县代码（6位）+ 乡/镇/街道 代码（3位）拼接组成 */
+    town_code: string;
+
+    /** 距离此点最近路 */
+    road: string;
+
+    /** 此点距离此路的距离 */
+    road_distance: number;
+
+    /** 距离此点最近poi点 */
+    poi: string;
+
+    /** 距离此点最近poi点的距离 */
+    poi_distance: number;
+
+    /** 此点在最近poi点的方向 */
+    poi_position: string;
+
+  }
+}

--- a/src/service/geocoder.d.ts
+++ b/src/service/geocoder.d.ts
@@ -3,8 +3,9 @@ type GeocoderGetLocationCallback = (result: GeocoderResult) => void;
 type GeocoderGetPointCallback = (result: GeocoderResult) => void;
 
 declare namespace T {
+
   class Geocoder {
-    /** 创建一个地址解析器的实例。 */
+    /** 创建一个地址解析器的实例。此类用于获取用户的地址解析 */
     constructor();
 
     /** 对指定的坐标点进行反地址解析。如果解析成功，则回调函数的参数为GeocoderResult对象。 */
@@ -125,4 +126,5 @@ declare namespace T {
     poi_position: string;
 
   }
+
 }

--- a/src/service/localCity.d.ts
+++ b/src/service/localCity.d.ts
@@ -1,0 +1,27 @@
+declare namespace T {
+
+  class LocalCity {
+    /** 创建一个获取本地城市位置的实例。 */
+    constructor();
+
+    /** 当获取城市信息后，回调函数会被调用，其参数为类型为LocalCityResult对象。 */
+    location(callback: LocalCityLocationCallback);
+  }
+
+  /** 此类表示LocalCity的定位结果。 */
+  interface LocalCityResult {
+
+    /** 城市所在中心点。 */
+    lnglat: LngLat;
+
+    /** 展示当前城市的最佳地图级别，如果您在使用此对象时提供了map实例，则地图级别将根据您提供的地图大小进行调整。 */
+    level: number;
+
+    /** 城市名称。 */
+    cityName: string;
+  }
+
+  /** 回调函数 */
+  type LocalCityLocationCallback = (result: LocalCityResult) => void;
+
+}

--- a/src/service/localCity.d.ts
+++ b/src/service/localCity.d.ts
@@ -1,11 +1,11 @@
 declare namespace T {
 
   class LocalCity {
-    /** 创建一个获取本地城市位置的实例。 */
+    /** 创建一个获取本地城市位置的实例。此类用于获取用户所在的城市位置信息。(根据用户IP自动定位到城市) */
     constructor();
 
     /** 当获取城市信息后，回调函数会被调用，其参数为类型为LocalCityResult对象。 */
-    location(callback: LocalCityLocationCallback);
+    location(callback: LocalCityLocationCallback): void;
   }
 
   /** 此类表示LocalCity的定位结果。 */
@@ -21,7 +21,6 @@ declare namespace T {
     cityName: string;
   }
 
-  /** 回调函数 */
   type LocalCityLocationCallback = (result: LocalCityResult) => void;
 
 }

--- a/src/service/localCity.d.ts
+++ b/src/service/localCity.d.ts
@@ -1,5 +1,4 @@
 declare namespace T {
-
   class LocalCity {
     /** 创建一个获取本地城市位置的实例。此类用于获取用户所在的城市位置信息。(根据用户IP自动定位到城市) */
     constructor();
@@ -19,6 +18,7 @@ declare namespace T {
 
     /** 城市名称。 */
     cityName: string;
+
   }
 
   type LocalCityLocationCallback = (result: LocalCityResult) => void;


### PR DESCRIPTION
感觉这些类多少有点问题的，AdministrativeDivision、DataSources类的返回结果都是404，调用没成功过；Geolocation类的callback不能传入箭头函数，只能传入匿名函数。LocalCity的callback也没有执行，它自己官网的实例都没有调用成功过。Geocoder返回的结果里有一个更详细的、完整的地址解析结果，但是类参考里又不写，给的函数调用返回的是精简版本的... 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 行政区划查询：支持地区信息搜索与数据获取
  * 地理编码服务：支持地址与坐标的相互转换
  * 地理位置定位：支持获取用户当前位置与精度信息
  * 数据源查询：支持多层级数据搜索功能
  * 本地城市检测：支持自动识别用户所在城市位置

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->